### PR TITLE
Catch more errors in Builder.createBuildStream

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,14 +36,20 @@
       }
     },
     "@types/bluebird": {
-      "version": "3.5.24",
-      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.24.tgz",
-      "integrity": "sha512-YeQoDpq4Lm8ppSBqAnAeF/xy1cYp/dMTif2JFcvmAbETMRlvKHT2iLcWu+WyYiJO3b3Ivokwo7EQca/xfLVJmg=="
+      "version": "3.5.20",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.20.tgz",
+      "integrity": "sha512-Wk41MVdF+cHBfVXj/ufUHJeO3BlIQr1McbHZANErMykaCWeDSZbH5erGjNBw2/3UlRdSxZbLfSuQTzFmPOYFsA=="
     },
     "@types/chai": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-3.5.2.tgz",
       "integrity": "sha1-wRzSgX06QBt7oPWkIPNcVhObHB4=",
+      "dev": true
+    },
+    "@types/depcheck": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/depcheck/-/depcheck-0.6.0.tgz",
+      "integrity": "sha512-l/1wJTM4G+aWVzonZJ8vx/xJp3flBLWgZMUrCWBaGysiCutl+q3Eu1lKPq6GYFasP7L19KZ3L/y1kv3X08R71w==",
       "dev": true
     },
     "@types/dockerode": {
@@ -52,6 +58,14 @@
       "integrity": "sha512-NSDdW9JUia7bLba87jTfZR/o1YcIFDcSC9HcdrXGJluHVfl8hXiUBFJwB9z3LSk/xmvv/pmEKzHFq6JmpNhlfg==",
       "requires": {
         "@types/events": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/duplexify": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@types/duplexify/-/duplexify-3.6.0.tgz",
+      "integrity": "sha512-5zOA53RUlzN74bvrSGwjudssD9F3a797sDZQkiYpUOxW+WHaXTCPz4/d5Dgi6FKnOqZ2CpaTo0DhgIfsXAOE/A==",
+      "requires": {
         "@types/node": "*"
       }
     },
@@ -67,6 +81,17 @@
       "version": "1.2.0",
       "resolved": "http://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
       "integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA=="
+    },
+    "@types/glob": {
+      "version": "5.0.36",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.36.tgz",
+      "integrity": "sha512-KEzSKuP2+3oOjYYjujue6Z3Yqis5HKA1BsIC+jZ1v3lrRNdsqyNNtX0rQf6LSuI4DJJ2z5UV//zBZCcvM0xikg==",
+      "dev": true,
+      "requires": {
+        "@types/events": "*",
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
     },
     "@types/jsonstream": {
       "version": "0.8.30",
@@ -86,6 +111,12 @@
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.119.tgz",
       "integrity": "sha512-Z3TNyBL8Vd/M9D9Ms2S3LmFq2sSMzahodD6rCS9V2N44HUMINb75jNkSuwAx7eo2ufqTdfOdtGQpNbieUjPQmw=="
     },
+    "@types/minimatch": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+      "dev": true
+    },
     "@types/mocha": {
       "version": "2.2.48",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.48.tgz",
@@ -101,9 +132,29 @@
       }
     },
     "@types/node": {
-      "version": "7.10.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.10.2.tgz",
-      "integrity": "sha512-RO4ig5taKmcrU4Rex8ojG1gpwFkjddzug9iPQSDvbewHN9vDpcFewevkaOK+KT+w1LeZnxbgOyfXwV4pxsQ4GQ=="
+      "version": "10.12.30",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.30.tgz",
+      "integrity": "sha512-nsqTN6zUcm9xtdJiM9OvOJ5EF0kOI8f1Zuug27O/rgtxCRJHGqncSWfCMZUP852dCKPsDsYXGvBhxfRjDBkF5Q=="
+    },
+    "@types/optimist": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/optimist/-/optimist-0.0.29.tgz",
+      "integrity": "sha1-qIc1gLOoS2msHmhzI7Ffu+uQR5o=",
+      "dev": true
+    },
+    "@types/prettier": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-1.16.1.tgz",
+      "integrity": "sha512-db6pZL5QY3JrlCHBhYQzYDci0xnoDuxfseUuguLRr3JNk+bnCfpkK6p8quiUDyO8A0vbpBKkk59Fw125etrNeA==",
+      "dev": true
+    },
+    "@types/tar-stream": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@types/tar-stream/-/tar-stream-1.6.0.tgz",
+      "integrity": "sha512-XG7FGVmxUvC5NW4h63K3PbB0xdC21xZBfoqmEz7YP2DdiTeYKmYAg8quSHMndNP3iXfs7C73rg4Q0W1dOPHBXQ==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "JSONStream": {
       "version": "1.3.5",
@@ -175,6 +226,15 @@
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
       "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
       "dev": true
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
     },
     "arr-diff": {
       "version": "4.0.0",
@@ -261,6 +321,94 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "dev": true
+    },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
+      }
+    },
+    "babel-messages": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
+      }
+    },
+    "babel-traverse": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "^6.26.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "debug": "^2.6.8",
+        "globals": "^9.18.0",
+        "invariant": "^2.2.2",
+        "lodash": "^4.17.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "globals": {
+          "version": "9.18.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "babel-types": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
+      }
+    },
+    "babylon": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
       "dev": true
     },
     "balanced-match": {
@@ -504,6 +652,30 @@
         }
       }
     },
+    "cliui": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wrap-ansi": "^2.0.0"
+      },
+      "dependencies": {
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        }
+      }
+    },
     "clone": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
@@ -515,6 +687,75 @@
       "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
       "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
       "dev": true
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
+    },
+    "coffee-script": {
+      "version": "1.12.7",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
+      "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==",
+      "dev": true
+    },
+    "coffeelint": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/coffeelint/-/coffeelint-1.16.2.tgz",
+      "integrity": "sha512-6mzgOo4zb17WfdrSui/cSUEgQ0AQkW3gXDht+6lHkfkqGUtSYKwGdGcXsDfAyuScVzTlTtKdfwkAlJWfqul7zg==",
+      "dev": true,
+      "requires": {
+        "coffee-script": "~1.11.0",
+        "glob": "^7.0.6",
+        "ignore": "^3.0.9",
+        "optimist": "^0.6.1",
+        "resolve": "^0.6.3",
+        "strip-json-comments": "^1.0.2"
+      },
+      "dependencies": {
+        "coffee-script": {
+          "version": "1.11.1",
+          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.11.1.tgz",
+          "integrity": "sha1-vxxHrWREOg2V0S3ysUfMCk2q1uk=",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "resolve": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.6.3.tgz",
+          "integrity": "sha1-3ZV5gufnNt699TtYpN2RdUV13UY=",
+          "dev": true
+        },
+        "strip-json-comments": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+          "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+          "dev": true
+        }
+      }
+    },
+    "coffeescope2": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/coffeescope2/-/coffeescope2-0.4.6.tgz",
+      "integrity": "sha1-FH8CcBXRWCP5eFl6uaEJQYGkHb0=",
+      "dev": true,
+      "requires": {
+        "globals": "^10.1.0"
+      }
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -592,6 +833,12 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true
+    },
+    "core-js": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
+      "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
       "dev": true
     },
     "core-util-is": {
@@ -770,10 +1017,41 @@
         }
       }
     },
+    "depcheck": {
+      "version": "0.6.11",
+      "resolved": "https://registry.npmjs.org/depcheck/-/depcheck-0.6.11.tgz",
+      "integrity": "sha512-wTVJ8cNilB8NfkzoBblcYqsB8LRfbjqKEwAOLD3YXIRigktSM7/lS9xQfVkAVujhjstmiQMZR0hkdHSnQxzb9A==",
+      "dev": true,
+      "requires": {
+        "babel-traverse": "^6.7.3",
+        "babylon": "^6.1.21",
+        "builtin-modules": "^1.1.1",
+        "deprecate": "^1.0.0",
+        "deps-regex": "^0.1.4",
+        "js-yaml": "^3.4.2",
+        "lodash": "^4.5.1",
+        "minimatch": "^3.0.2",
+        "require-package-name": "^2.0.1",
+        "walkdir": "0.0.11",
+        "yargs": "^8.0.2"
+      }
+    },
+    "deprecate": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/deprecate/-/deprecate-1.1.0.tgz",
+      "integrity": "sha512-b5dDNQYdy2vW9WXUD8+RQlfoxvqztLLhDE+T7Gd37I5E8My7nJkKu6FmhdDeRWJ8B+yjZKuwjCta8pgi8kgSqA==",
+      "dev": true
+    },
     "deprecated": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
       "integrity": "sha1-+cmvVGSvoeepcUWKi97yqpTVuxk=",
+      "dev": true
+    },
+    "deps-regex": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deps-regex/-/deps-regex-0.1.4.tgz",
+      "integrity": "sha1-UYZnt2kUYKXn4KNBvnbrfOgJAYQ=",
       "dev": true
     },
     "detect-file": {
@@ -982,6 +1260,18 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
     "event-emitter": {
@@ -1368,6 +1658,12 @@
         "globule": "~0.1.0"
       }
     },
+    "get-caller-file": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+      "dev": true
+    },
     "get-stdin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
@@ -1557,6 +1853,12 @@
         "is-windows": "^1.0.1",
         "which": "^1.2.14"
       }
+    },
+    "globals": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-10.4.0.tgz",
+      "integrity": "sha512-uNUtxIZpGyuaq+5BqGGQHsL4wUlJAXRqOm6g3Y48/CWNGTLONgBibI0lh6lGxjR2HljFYUfszb+mk4WkgMntsA==",
+      "dev": true
     },
     "globule": {
       "version": "0.1.0",
@@ -2368,6 +2670,12 @@
       "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
       "dev": true
     },
+    "ignore": {
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+      "dev": true
+    },
     "in-publish": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
@@ -2408,6 +2716,21 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
       "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
+      "dev": true
+    },
+    "invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.0.0"
+      }
+    },
+    "invert-kv": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
       "dev": true
     },
     "is-absolute": {
@@ -2536,6 +2859,15 @@
         "number-is-nan": "^1.0.0"
       }
     },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "^1.0.0"
+      }
+    },
     "is-glob": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
@@ -2651,6 +2983,22 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.12.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.2.tgz",
+      "integrity": "sha512-QHn/Lh/7HhZ/Twc7vJYQTkjuCa0kaCcDcjK5Zlk2rvnUpy7DxMJ23+Jc2dcyvltwQVg1nygAVlB2oRDFHoRS5Q==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
     "json-stable-stringify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
@@ -2700,6 +3048,15 @@
         "readable-stream": "^2.0.5"
       }
     },
+    "lcid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "dev": true,
+      "requires": {
+        "invert-kv": "^1.0.0"
+      }
+    },
     "liftoff": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.5.0.tgz",
@@ -2737,6 +3094,24 @@
           "requires": {
             "is-utf8": "^0.2.0"
           }
+        }
+      }
+    },
+    "locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "dev": true,
+      "requires": {
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "dependencies": {
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
         }
       }
     },
@@ -3016,6 +3391,15 @@
         }
       }
     },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
     "loud-rejection": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
@@ -3088,6 +3472,15 @@
       "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
       "dev": true
     },
+    "mem": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+      "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^1.0.0"
+      }
+    },
     "memoizee": {
       "version": "0.4.14",
       "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.14.tgz",
@@ -3130,6 +3523,12 @@
         }
       }
     },
+    "merge": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
+      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
+      "dev": true
+    },
     "merge-stream": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
@@ -3159,6 +3558,12 @@
         "snapdragon": "^0.8.1",
         "to-regex": "^3.0.2"
       }
+    },
+    "mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
@@ -3465,6 +3870,16 @@
         "wrappy": "1"
       }
     },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
+      "requires": {
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
+      }
+    },
     "orchestrator": {
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.8.tgz",
@@ -3508,10 +3923,62 @@
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
+    "os-locale": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+      "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+      "dev": true,
+      "requires": {
+        "execa": "^0.7.0",
+        "lcid": "^1.0.0",
+        "mem": "^1.1.0"
+      },
+      "dependencies": {
+        "execa": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        }
+      }
+    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
+    },
+    "p-limit": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "dev": true,
+      "requires": {
+        "p-try": "^1.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "dev": true,
+      "requires": {
+        "p-limit": "^1.1.0"
+      }
+    },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
       "dev": true
     },
     "parse-filepath": {
@@ -3733,6 +4200,12 @@
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
       "dev": true
     },
+    "prettier": {
+      "version": "1.16.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.4.tgz",
+      "integrity": "sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==",
+      "dev": true
+    },
     "pretty-hrtime": {
       "version": "1.0.3",
       "resolved": "http://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
@@ -3832,6 +4305,12 @@
         "strip-indent": "^1.0.1"
       }
     },
+    "regenerator-runtime": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+      "dev": true
+    },
     "regex-cache": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
@@ -3884,6 +4363,18 @@
       "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
       "dev": true
     },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-main-filename": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+      "dev": true
+    },
     "require-npm4-to-publish": {
       "version": "1.0.0",
       "resolved": "http://registry.npmjs.org/require-npm4-to-publish/-/require-npm4-to-publish-1.0.0.tgz",
@@ -3898,6 +4389,66 @@
           "version": "5.6.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
           "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+          "dev": true
+        }
+      }
+    },
+    "require-package-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/require-package-name/-/require-package-name-2.0.1.tgz",
+      "integrity": "sha1-wR6XJ2tluOKSP3Xav1+y7ww4Qbk=",
+      "dev": true
+    },
+    "resin-lint": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/resin-lint/-/resin-lint-3.0.1.tgz",
+      "integrity": "sha512-KJOsXguJcJrV/MTI8U4JstmrRwjoA+pOoF+cKS9sbeOfbDidmHZWtvkqSJe07CZkCf/Rf6RBmAUD2+tppWP2qw==",
+      "dev": true,
+      "requires": {
+        "@types/bluebird": "^3.5.20",
+        "@types/depcheck": "^0.6.0",
+        "@types/glob": "^5.0.35",
+        "@types/node": "^8.5.2",
+        "@types/optimist": "0.0.29",
+        "@types/prettier": "^1.13.2",
+        "bluebird": "^3.5.0",
+        "coffee-script": "^1.10.0",
+        "coffeelint": "^1.15.0",
+        "coffeescope2": "^0.4.5",
+        "depcheck": "^0.6.7",
+        "glob": "^7.0.3",
+        "merge": "^1.2.0",
+        "optimist": "^0.6.1",
+        "prettier": "^1.14.2",
+        "tslint": "^5.8.0",
+        "tslint-config-prettier": "^1.15.0",
+        "typescript": "^2.6.2"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "8.10.43",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.43.tgz",
+          "integrity": "sha512-5m5W13HR2k3cu88mpzlnPBBv5+GyMHtj4F0P83RG4mqoC0AYVYHVMHfF3SgwKNtqEZiZQASMxU92QsLEekKcnw==",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "typescript": {
+          "version": "2.9.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
+          "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
           "dev": true
         }
       }
@@ -3982,6 +4533,12 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
       "integrity": "sha1-kM/xnQLgcCf9dn9erT57ldHnOAw=",
+      "dev": true
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
     "set-value": {
@@ -4250,6 +4807,12 @@
         "extend-shallow": "^3.0.0"
       }
     },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -4290,6 +4853,39 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+    },
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
     },
     "string_decoder": {
       "version": "1.1.1",
@@ -4488,6 +5084,12 @@
       "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
       "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
     },
+    "to-fast-properties": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+      "dev": true
+    },
     "to-object-path": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
@@ -4582,6 +5184,111 @@
         }
       }
     },
+    "tslib": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+      "dev": true
+    },
+    "tslint": {
+      "version": "5.13.1",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.13.1.tgz",
+      "integrity": "sha512-fplQqb2miLbcPhyHoMV4FU9PtNRbgmm/zI5d3SZwwmJQM6V0eodju+hplpyfhLWpmwrDNfNYU57uYRb8s0zZoQ==",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "^6.22.0",
+        "builtin-modules": "^1.1.1",
+        "chalk": "^2.3.0",
+        "commander": "^2.12.1",
+        "diff": "^3.2.0",
+        "glob": "^7.1.1",
+        "js-yaml": "^3.7.0",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "resolve": "^1.3.2",
+        "semver": "^5.3.0",
+        "tslib": "^1.8.0",
+        "tsutils": "^2.27.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "commander": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+          "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+          "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "tslint-config-prettier": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/tslint-config-prettier/-/tslint-config-prettier-1.18.0.tgz",
+      "integrity": "sha512-xPw9PgNPLG3iKRxmK7DWr+Ea/SzrvfHtjFt5LBl61gk2UBG/DB9kCXRjv+xyIU1rUtnayLeMUVJBcMX8Z17nDg==",
+      "dev": true
+    },
+    "tsutils": {
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
+      "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.8.1"
+      }
+    },
     "type-detect": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
@@ -4594,9 +5301,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-      "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+      "version": "3.3.3333",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.3333.tgz",
+      "integrity": "sha512-JjSKsAfuHBE/fB2oZ8NxtRTk5iGcg6hkYXMnZ3Wc+b2RSqejEqTaem11mHASMnFilHrax3sLK0GDzcJrekZYLw==",
       "dev": true
     },
     "unc-path-regex": {
@@ -4822,6 +5529,12 @@
         }
       }
     },
+    "walkdir": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.11.tgz",
+      "integrity": "sha1-oW0CXrkxvQO1LzCMrtD0D86+lTI=",
+      "dev": true
+    },
     "which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -4829,6 +5542,41 @@
       "dev": true,
       "requires": {
         "isexe": "^2.0.0"
+      }
+    },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
+    },
+    "wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+      "dev": true
+    },
+    "wrap-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
+      },
+      "dependencies": {
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        }
       }
     },
     "wrappy": {
@@ -4841,11 +5589,120 @@
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
+    "y18n": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+      "dev": true
+    },
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
+    },
+    "yargs": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
+      "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+      "dev": true,
+      "requires": {
+        "camelcase": "^4.1.0",
+        "cliui": "^3.2.0",
+        "decamelize": "^1.1.1",
+        "get-caller-file": "^1.0.1",
+        "os-locale": "^2.0.0",
+        "read-pkg-up": "^2.0.0",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^1.0.1",
+        "set-blocking": "^2.0.0",
+        "string-width": "^2.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^3.2.1",
+        "yargs-parser": "^7.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "dev": true,
+          "requires": {
+            "pify": "^2.0.0"
+          }
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^2.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^2.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+          "dev": true,
+          "requires": {
+            "find-up": "^2.0.0",
+            "read-pkg": "^2.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+      "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+      "dev": true,
+      "requires": {
+        "camelcase": "^4.1.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        }
+      }
     },
     "yn": {
       "version": "1.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -148,6 +148,12 @@
       "integrity": "sha512-db6pZL5QY3JrlCHBhYQzYDci0xnoDuxfseUuguLRr3JNk+bnCfpkK6p8quiUDyO8A0vbpBKkk59Fw125etrNeA==",
       "dev": true
     },
+    "@types/rewire": {
+      "version": "2.5.28",
+      "resolved": "https://registry.npmjs.org/@types/rewire/-/rewire-2.5.28.tgz",
+      "integrity": "sha512-uD0j/AQOa5le7afuK+u+woi8jNKF1vf3DN0H7LCJhft/lNNibUr7VcAesdgtWfEKveZol3ZG1CJqwx2Bhrnl8w==",
+      "dev": true
+    },
     "@types/tar-stream": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@types/tar-stream/-/tar-stream-1.6.0.tgz",
@@ -171,6 +177,41 @@
       "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
       "dev": true
     },
+    "acorn-jsx": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "dev": true,
+      "requires": {
+        "acorn": "^3.0.4"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+          "dev": true
+        }
+      }
+    },
+    "ajv": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "dev": true,
+      "requires": {
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
+      }
+    },
+    "ajv-keywords": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+      "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+      "dev": true
+    },
     "ansi-cyan": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
@@ -179,6 +220,12 @@
       "requires": {
         "ansi-wrap": "0.1.0"
       }
+    },
+    "ansi-escapes": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+      "dev": true
     },
     "ansi-gray": {
       "version": "0.1.1",
@@ -584,6 +631,21 @@
         "unset-value": "^1.0.0"
       }
     },
+    "caller-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "dev": true,
+      "requires": {
+        "callsites": "^0.2.0"
+      }
+    },
+    "callsites": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+      "dev": true
+    },
     "camelcase": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
@@ -624,10 +686,22 @@
         "supports-color": "^2.0.0"
       }
     },
+    "chardet": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+      "dev": true
+    },
     "chownr": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
       "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
+    },
+    "circular-json": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "dev": true
     },
     "class-utils": {
       "version": "0.3.6",
@@ -651,6 +725,21 @@
           }
         }
       }
+    },
+    "cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^2.0.0"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "dev": true
     },
     "cliui": {
       "version": "3.2.0",
@@ -686,6 +775,12 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
       "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
+      "dev": true
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
     "code-point-at": {
@@ -967,6 +1062,12 @@
         }
       }
     },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
     "defaults": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
@@ -1125,6 +1226,15 @@
         "tar-fs": "~1.16.3"
       }
     },
+    "doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
+    },
     "dts-generator": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/dts-generator/-/dts-generator-2.1.0.tgz",
@@ -1262,10 +1372,184 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
+    "eslint": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+      "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
+      "dev": true,
+      "requires": {
+        "ajv": "^5.3.0",
+        "babel-code-frame": "^6.22.0",
+        "chalk": "^2.1.0",
+        "concat-stream": "^1.6.0",
+        "cross-spawn": "^5.1.0",
+        "debug": "^3.1.0",
+        "doctrine": "^2.1.0",
+        "eslint-scope": "^3.7.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^3.5.4",
+        "esquery": "^1.0.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.2",
+        "globals": "^11.0.1",
+        "ignore": "^3.3.3",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^3.0.6",
+        "is-resolvable": "^1.0.0",
+        "js-yaml": "^3.9.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.2",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "pluralize": "^7.0.0",
+        "progress": "^2.0.0",
+        "regexpp": "^1.0.1",
+        "require-uncached": "^1.0.3",
+        "semver": "^5.3.0",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "~2.0.1",
+        "table": "4.0.2",
+        "text-table": "~0.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "globals": {
+          "version": "11.11.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
+          "integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+          "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "eslint-scope": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
+      "integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "dev": true
+    },
+    "espree": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+      "dev": true,
+      "requires": {
+        "acorn": "^5.5.0",
+        "acorn-jsx": "^3.0.0"
+      }
+    },
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "esquery": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.0.0"
+      }
+    },
+    "esrecurse": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.1.0"
+      }
+    },
+    "estraverse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
       "dev": true
     },
     "esutils": {
@@ -1450,6 +1734,17 @@
         }
       }
     },
+    "external-editor": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+      "dev": true,
+      "requires": {
+        "chardet": "^0.4.0",
+        "iconv-lite": "^0.4.17",
+        "tmp": "^0.0.33"
+      }
+    },
     "extglob": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
@@ -1525,6 +1820,43 @@
         "color-support": "^1.1.3",
         "parse-node-version": "^1.0.0",
         "time-stamp": "^1.0.0"
+      }
+    },
+    "fast-deep-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      }
+    },
+    "file-entry-cache": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
       }
     },
     "filename-regex": {
@@ -1609,6 +1941,18 @@
       "integrity": "sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q==",
       "dev": true
     },
+    "flat-cache": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
+      "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
+      "dev": true,
+      "requires": {
+        "circular-json": "^0.3.1",
+        "graceful-fs": "^4.1.2",
+        "rimraf": "~2.6.2",
+        "write": "^0.2.1"
+      }
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -1647,6 +1991,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
     "gaze": {
@@ -2670,10 +3020,25 @@
       "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
       "dev": true
     },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
     "ignore": {
       "version": "3.3.10",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
       "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+      "dev": true
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
     "in-publish": {
@@ -2711,6 +3076,80 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
+    },
+    "inquirer": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.0",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^2.0.4",
+        "figures": "^2.0.0",
+        "lodash": "^4.3.0",
+        "mute-stream": "0.0.7",
+        "run-async": "^2.2.0",
+        "rx-lite": "^4.0.8",
+        "rx-lite-aggregates": "^4.0.8",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^4.0.0",
+        "through": "^2.3.6"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
     },
     "interpret": {
       "version": "1.1.0",
@@ -2933,6 +3372,12 @@
         "is-unc-path": "^1.0.0"
       }
     },
+    "is-resolvable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+      "dev": true
+    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -2999,6 +3444,12 @@
         "esprima": "^4.0.0"
       }
     },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+      "dev": true
+    },
     "json-stable-stringify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
@@ -3007,6 +3458,12 @@
       "requires": {
         "jsonify": "~0.0.0"
       }
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
     },
     "json3": {
       "version": "3.3.2",
@@ -3055,6 +3512,16 @@
       "dev": true,
       "requires": {
         "invert-kv": "^1.0.0"
+      }
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "liftoff": {
@@ -3682,6 +4149,12 @@
         "duplexer2": "0.0.2"
       }
     },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true
+    },
     "mz": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
@@ -3715,6 +4188,12 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.6.tgz",
       "integrity": "sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==",
+      "dev": true
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
     "next-tick": {
@@ -3870,6 +4349,15 @@
         "wrappy": "1"
       }
     },
+    "onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^1.0.0"
+      }
+    },
     "optimist": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
@@ -3878,6 +4366,28 @@
       "requires": {
         "minimist": "~0.0.1",
         "wordwrap": "~0.0.2"
+      }
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+          "dev": true
+        }
       }
     },
     "orchestrator": {
@@ -3950,6 +4460,12 @@
           }
         }
       }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
     },
     "p-finally": {
       "version": "1.0.0",
@@ -4067,6 +4583,12 @@
       "version": "1.0.1",
       "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true
     },
     "path-key": {
@@ -4188,10 +4710,22 @@
         }
       }
     },
+    "pluralize": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+      "dev": true
+    },
     "posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "dev": true
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
     "preserve": {
@@ -4216,6 +4750,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+    },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -4330,6 +4870,12 @@
         "safe-regex": "^1.1.0"
       }
     },
+    "regexpp": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+      "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
+      "dev": true
+    },
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -4398,6 +4944,16 @@
       "resolved": "https://registry.npmjs.org/require-package-name/-/require-package-name-2.0.1.tgz",
       "integrity": "sha1-wR6XJ2tluOKSP3Xav1+y7ww4Qbk=",
       "dev": true
+    },
+    "require-uncached": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "dev": true,
+      "requires": {
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
+      }
     },
     "resin-lint": {
       "version": "3.0.1",
@@ -4472,17 +5028,42 @@
         "global-modules": "^1.0.0"
       }
     },
+    "resolve-from": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+      "dev": true
+    },
     "resolve-url": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
     },
+    "restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
+      "requires": {
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
     "ret": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
+    },
+    "rewire": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/rewire/-/rewire-4.0.1.tgz",
+      "integrity": "sha512-+7RQ/BYwTieHVXetpKhT11UbfF6v1kGhKFrtZN7UDL2PybMsSt/rpLWeEUGF5Ndsl1D5BxiCB14VDJyoX+noYw==",
+      "dev": true,
+      "requires": {
+        "eslint": "^4.19.1"
+      }
     },
     "rimraf": {
       "version": "2.6.2",
@@ -4509,6 +5090,30 @@
         }
       }
     },
+    "run-async": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "dev": true,
+      "requires": {
+        "is-promise": "^2.1.0"
+      }
+    },
+    "rx-lite": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+      "dev": true
+    },
+    "rx-lite-aggregates": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+      "dev": true,
+      "requires": {
+        "rx-lite": "*"
+      }
+    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -4522,6 +5127,12 @@
       "requires": {
         "ret": "~0.1.10"
       }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "semver": {
       "version": "4.3.6",
@@ -4590,6 +5201,23 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
+    },
+    "slice-ansi": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "^2.0.0"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        }
+      }
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -4968,6 +5596,57 @@
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
       "dev": true
     },
+    "table": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+      "dev": true,
+      "requires": {
+        "ajv": "^5.2.3",
+        "ajv-keywords": "^2.1.0",
+        "chalk": "^2.1.0",
+        "lodash": "^4.17.4",
+        "slice-ansi": "1.0.0",
+        "string-width": "^2.1.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "tar-fs": {
       "version": "1.16.3",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
@@ -4992,6 +5671,12 @@
         "to-buffer": "^1.1.1",
         "xtend": "^4.0.0"
       }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
     },
     "thenify": {
       "version": "3.3.0",
@@ -5057,6 +5742,15 @@
       "requires": {
         "es5-ext": "~0.10.46",
         "next-tick": "1"
+      }
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "~1.0.2"
       }
     },
     "to-absolute-glob": {
@@ -5287,6 +5981,15 @@
       "dev": true,
       "requires": {
         "tslib": "^1.8.1"
+      }
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2"
       }
     },
     "type-detect": {
@@ -5583,6 +6286,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "write": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
     },
     "xtend": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "devDependencies": {
     "@types/chai": "^3.4.35",
     "@types/mocha": "^2.2.39",
+    "@types/rewire": "^2.5.28",
     "chai": "^3.5.0",
     "dts-generator": "^2.1.0",
     "gulp": "^3.9.1",
@@ -61,6 +62,7 @@
     "mocha": "^3.2.0",
     "require-npm4-to-publish": "^1.0.0",
     "resin-lint": "^3.0.1",
+    "rewire": "^4.0.1",
     "ts-node": "^2.1.0",
     "typescript": "^3.2.1"
   }

--- a/package.json
+++ b/package.json
@@ -5,12 +5,15 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "scripts": {
-    "clean": "rm -rf build",
     "build": "npm run clean && tsc --project tsconfig.publish.json",
     "build:test": "npm run clean && tsc --project .",
-    "test": "npm run build:test && mocha build/test",
+    "clean": "rm -rf build",
+    "lint": "resin-lint --typescript src/ test/ && tsc --noEmit",
     "prepublish": "require-npm4-to-publish",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "pretest": "npm run lint",
+    "prettify": "prettier --config ./node_modules/resin-lint/config/.prettierrc --write \"{src,test,typings}/**/*.ts\"",
+    "test": "npm run build:test && mocha build/test"
   },
   "author": "Cameron Diver <cameron@resin.io>",
   "license": "Apache-2.0",
@@ -23,23 +26,25 @@
   },
   "homepage": "https://github.com/resin-io/resin-docker-build#readme",
   "dependencies": {
-    "@types/bluebird": "^3.0.37",
+    "@types/bluebird": "3.5.20",
     "@types/dockerode": "2.5.5",
-    "@types/event-stream": "^3.3.30",
-    "@types/jsonstream": "^0.8.28",
+    "@types/duplexify": "3.6.0",
+    "@types/event-stream": "^3.3.34",
+    "@types/jsonstream": "^0.8.30",
     "@types/klaw": "^1.3.1",
     "@types/lodash": "^4.14.51",
     "@types/mz": "0.0.30",
-    "@types/node": "^7.0.2",
+    "@types/node": "^10.12.11",
+    "@types/tar-stream": "1.6.0",
     "JSONStream": "^1.3.0",
     "bluebird": "^3.4.7",
     "dockerode": "^2.5.5",
     "duplexify": "^3.5.0",
-    "event-stream": "^3.3.4",
+    "event-stream": "^3.3.5",
     "klaw": "^1.3.1",
     "lodash": "^4.17.4",
     "mz": "^2.6.0",
-    "tar-stream": "^1.5.2"
+    "tar-stream": "^1.6.2"
   },
   "devDependencies": {
     "@types/chai": "^3.4.35",
@@ -55,7 +60,8 @@
     "gulp-util": "^3.0.8",
     "mocha": "^3.2.0",
     "require-npm4-to-publish": "^1.0.0",
+    "resin-lint": "^3.0.1",
     "ts-node": "^2.1.0",
-    "typescript": "^2.2.1"
+    "typescript": "^3.2.1"
   }
 }

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -15,27 +15,23 @@
  * limitations under the License.
  */
 
-import * as Bluebird from 'bluebird'
-import * as Dockerode from 'dockerode'
-import * as _ from 'lodash'
-import * as fs from 'mz/fs'
-import * as path from 'path'
-
-// Type-less imports
-const tar = require('tar-stream')
-const duplexify = require('duplexify')
-// Following types are available, but do not work...
-const es = require('event-stream')
-const JSONStream = require('JSONStream')
+import * as Bluebird from 'bluebird';
+import * as Dockerode from 'dockerode';
+import * as duplexify from 'duplexify';
+import * as es from 'event-stream';
+import * as JSONStream from 'JSONStream';
+import * as _ from 'lodash';
+import * as fs from 'mz/fs';
+import * as path from 'path';
+import { Duplex } from 'stream';
+import * as tar from 'tar-stream';
 
 // Import hook definitions
-import * as Plugin from './plugin'
-import * as Utils from './utils'
+import * as Plugin from './plugin';
+import * as Utils from './utils';
 
-Bluebird.promisifyAll(tar)
-
-export type ErrorHandler = (error: Error) => void
-const emptyHandler: ErrorHandler = () => {}
+export type ErrorHandler = (error: Error) => void;
+const emptyHandler: ErrorHandler = () => undefined;
 
 /**
  * This class is responsible for interfacing with the docker daemon to
@@ -45,20 +41,21 @@ const emptyHandler: ErrorHandler = () => {}
  *
  */
 export default class Builder {
-
-	private docker: Dockerode
-	private layers: string[]
+	private docker: Dockerode;
+	private layers: string[];
 
 	private constructor(docker: Dockerode) {
-		this.docker = docker
+		this.docker = docker;
 	}
 
 	public static fromDockerode(docker: Dockerode) {
 		return new Builder(docker);
 	}
-	
+
 	public static fromDockerOpts(dockerOpts: Dockerode.DockerOptions) {
-		return new Builder(new Dockerode(_.merge(dockerOpts, { Promise: Bluebird })));
+		return new Builder(
+			new Dockerode(_.merge(dockerOpts, { Promise: Bluebird })),
+		);
 	}
 
 	/**
@@ -67,82 +64,88 @@ export default class Builder {
 	 * as a tar archive to build. The stream can also be read from, and the data
 	 * returned will be the output of the docker daemon build.
 	 *
-	 * @returns {NodeJS.ReadWriteStream}
-	 *	A promise which resolves with a bi-directional stream, which is connected
-	 *	to the docker daemon.
+	 * @returns A bi-directional stream connected to the docker daemon
 	 */
-	public createBuildStream(buildOpts: Object, hooks: Plugin.BuildHooks = {}, handler: ErrorHandler = emptyHandler): NodeJS.ReadWriteStream {
-
-		const self = this
-
-		this.layers = []
+	public createBuildStream(
+		buildOpts: { [key: string]: any },
+		hooks: Plugin.BuildHooks = {},
+		handler: ErrorHandler = emptyHandler,
+	): NodeJS.ReadWriteStream {
+		const self = this;
+		this.layers = [];
 
 		// Create a stream to be passed into the docker daemon
-		const inputStream = es.through()
+		const inputStream = es.through<Duplex>();
 
 		// Create a bi-directional stream
-		const dup = duplexify()
+		const dup = duplexify();
 
 		// Connect the input stream to the rw stream
-		dup.setWritable(inputStream)
+		dup.setWritable(inputStream);
 
 		Bluebird.resolve(this.docker.buildImage(inputStream, buildOpts))
-		.then((res: NodeJS.ReadWriteStream) => {
+			.then((res: NodeJS.ReadWriteStream) => {
+				let errored = false;
+				const outputStream = res
+					// parse the json objects
+					.pipe(JSONStream.parse())
+					// Don't use fat-arrow syntax here, to capture 'this' from es
+					.pipe(
+						es.through<Duplex>(function(data: any): void {
+							if (data == null) {
+								return;
+							}
+							if (data.error) {
+								errored = true;
+								dup.destroy(new Error(data.error));
+							} else {
+								// Store image layers, so that they can be deleted by the caller
+								// if necessary
+								const sha = Utils.extractLayer(data.stream);
+								if (sha !== undefined) {
+									self.layers.push(sha);
+								}
 
-			let errored = false
-			const outputStream = res
-			// parse the json objects
-			.pipe(JSONStream.parse())
-			// Don't use fat-arrow syntax here, to capture 'this' from es
-			.pipe(es.through(function(data: any): void {
-				if (data == null) {
-					return
-				}
-				if (data.error) {
-					errored = true
-					dup.destroy(new Error(data.error))
-				} else {
-					// Store image layers, so that they can be deleted by the caller
-					// if necessary
-					const sha = Utils.extractLayer(data.stream)
-					if (sha !== undefined) {
-						self.layers.push(sha)
+								this.emit('data', data.stream);
+							}
+						}),
+					);
+
+				// Catch any errors the stream produces
+				outputStream.on('error', (err: Error) => {
+					errored = true;
+					self.callHook(hooks, 'buildFailure', handler, err, self.layers);
+				});
+				dup.on('error', (err: Error) => {
+					errored = true;
+					self.callHook(hooks, 'buildFailure', handler, err, self.layers);
+				});
+
+				// Setup the buildSuccess hook. This handler is not called on
+				// error so we can use it to propagate the success information
+				outputStream.on('end', () => {
+					if (!errored) {
+						this.callHook(
+							hooks,
+							'buildSuccess',
+							handler,
+							_.last(this.layers),
+							this.layers,
+						);
 					}
-
-					this.emit('data', data.stream)
-				}
-			}))
-
-			// Catch any errors the stream produces
-			outputStream.on('error', (err: Error) => {
-				errored = true
-				self.callHook(hooks, 'buildFailure', handler, err, self.layers)
+				});
+				// Connect the output of the docker daemon to the duplex stream
+				dup.setReadable(outputStream);
 			})
-			dup.on('error', (err: Error) => {
-				errored = true
-				self.callHook(hooks, 'buildFailure', handler, err, self.layers)
-			})
-
-			// Setup the buildSuccess hook. This handler is not called on
-			// error so we can use it to propagate the success information
-			outputStream.on('end', () => {
-				if (!errored) {
-					this.callHook(hooks, 'buildSuccess', handler, _.last(this.layers), this.layers)
-				}
-			})
-			// Connect the output of the docker daemon to the duplex stream
-			dup.setReadable(outputStream)
-
-		})
-		.catch((err: Error) => {
-			// Call the plugin's error handler
-			self.callHook(hooks, 'buildFailure', handler, err, self.layers)
-		})
+			.catch((err: Error) => {
+				// Call the plugin's error handler
+				self.callHook(hooks, 'buildFailure', handler, err, self.layers);
+			});
 
 		// Call the correct hook with the build stream
-		this.callHook(hooks, 'buildStream', handler, dup)
+		this.callHook(hooks, 'buildStream', handler, dup);
 		// and also return it
-		return dup
+		return dup;
 	}
 
 	/**
@@ -150,73 +153,79 @@ export default class Builder {
 	 * and stream it to the docker daemon. It will then return a stream connected to
 	 * the output of the docker daemon.
 	 *
-	 * @param {string} dirPath
-	 *	The directory path to send to the docker daemon.
+	 * @param dirPath Directory path to send to the docker daemon
+	 * @param buildOpts Build options to pass to the docker daemon
 	 *
-	 * @param {Object} buildOpts
-	 *	Build options to pass to the docker daemon.
-	 *
-	 * @returns {Bluebird<NodeJS.ReadableStream>}
-	 *	A stream which is connected to the output of the docker daemon
+	 * @returns Promise of a stream connected to the docker daemon
 	 */
-	public buildDir(dirPath: string, buildOpts: Object, hooks: Plugin.BuildHooks, handler: ErrorHandler = emptyHandler): Bluebird<NodeJS.ReadableStream> {
-		const pack = tar.pack()
+	public buildDir(
+		dirPath: string,
+		buildOpts: { [key: string]: any },
+		hooks: Plugin.BuildHooks,
+		handler: ErrorHandler = emptyHandler,
+	): Bluebird<NodeJS.ReadableStream> {
+		const pack = tar.pack();
 
 		return Utils.directoryToFiles(dirPath)
 			.map((file: string) => {
 				// Work out the relative path
-				const relPath = path.relative(path.resolve(dirPath), file)
-				return Bluebird.all([relPath, fs.stat(file), fs.readFile(file)])
+				const relPath = path.relative(path.resolve(dirPath), file);
+				return Bluebird.all([relPath, fs.stat(file), fs.readFile(file)]);
 			})
 			.map((fileInfo: [string, fs.Stats, Buffer]) => {
-				return pack.entryAsync({ name: fileInfo[0], size: fileInfo[1].size }, fileInfo[2])
+				return Bluebird.fromCallback(callback =>
+					pack.entry(
+						{ name: fileInfo[0], size: fileInfo[1].size },
+						fileInfo[2],
+						callback,
+					),
+				);
 			})
 			.then(() => {
 				// Tell the tar stream we're done
-				pack.finalize()
+				pack.finalize();
 				// Create a build stream to send the data to
-				let stream = this.createBuildStream(buildOpts, hooks, handler)
+				const stream = this.createBuildStream(buildOpts, hooks, handler);
 				// Write the tar archive to the stream
-				pack.pipe(stream)
+				pack.pipe(stream);
 				// ...and return it for reading
-				return stream
-			})
+				return stream;
+			});
 	}
 
 	/**
 	 * Internal function to call a hook, if it has been registered for the build.
 	 *
-	 * @param {string} name
-	 *	The name of the hook to be called.
+	 * @param args The arguments to pass to the hook. The values will be
+	 * unwrapped before being passed to the callback.
 	 *
-	 * @param {any[]} args
-	 *	The arguments to pass to the hook. The values will be unwrapped before
-	 *	being passed to the callback.
-	 *
-	 * @returns {any} The return value of the function, or nothing if the
-	 * function does not exist or does not provide a return value
+	 * @returns Promise that resolves to the return value of the hook function,
+	 * or to undefined if the a hook function is not provided.
 	 */
-	private callHook(hooks: Plugin.BuildHooks, hook: Plugin.ValidHook, handler: ErrorHandler, ...args: any[]): Bluebird<any> {
+	private callHook(
+		hooks: Plugin.BuildHooks,
+		hook: Plugin.ValidHook,
+		handler: ErrorHandler,
+		...args: any[]
+	): Bluebird<any> {
 		if (hook in hooks) {
 			try {
 				// Spread the arguments onto the callback function
-				const fn = hooks[hook]
+				const fn = hooks[hook];
 				if (_.isFunction(fn)) {
-					const val = fn.apply(null, args)
+					const val = fn.apply(null, args);
 					// If we can add a catch handler
-					if(val != null && _.isFunction(val.catch) && _.isFunction(handler)) {
-						val.catch(handler)
+					if (val != null && _.isFunction(val.catch) && _.isFunction(handler)) {
+						val.catch(handler);
 					}
-					return val
+					return val;
 				}
 			} catch (e) {
 				if (_.isFunction(handler)) {
-					handler(e)
+					handler(e);
 				}
 			}
 		}
-		return Bluebird.resolve()
+		return Bluebird.resolve();
 	}
-
 }
-

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,10 +1,25 @@
 /**
+ * @license
+ * Copyright 2019 Balena Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
  * ValidHooks: A list of valid hooks to enable the compiler to do
  * some safety checking
  */
-export type ValidHook = 'buildStream'
-                      | 'buildSuccess'
-                      | 'buildFailure'
+export type ValidHook = 'buildStream' | 'buildSuccess' | 'buildFailure';
 
 /**
  * BuildHooks
@@ -22,42 +37,34 @@ export interface BuildHooks {
 	 * This hook is called after a build is started, with `stream` being populated with
 	 * a ReadableStream which is connected to the output of the docker daemon.
 	 *
-	 * @param {NodeJS.ReadWriteStream} stream
-	 *	A duplex stream which can be used to send and recieve data with the
-	 *	docker daemon.
-	 *
+	 * @param stream A duplex stream that can be used to send and receive data
+	 * to/from the docker daemon.
 	 *
 	 * Example implementation:
 	 *
 	 * buildStream = (stream) => {
-	 *	stream.pipe(process.stdout)
+	 *     stream.pipe(process.stdout);
 	 * }
 	 *
 	 */
-	buildStream?: (stream: NodeJS.ReadWriteStream) => void
+	buildStream?: (stream: NodeJS.ReadWriteStream) => void;
 
 	/**
 	 * This hook will be called after a build has successfully finished.
 	 *
-	 * @param {string} imageId
-	 *	This parameter will be populated with the digest which points to the
-	 *	built image.
-	 * @param {string[]} layers
-	 *	Intermediate layers used by the build, can be used for GC. The last
-	 *	id in the layers array is also the imageId, so care should be taken to
-	 *	not GC the built image.
+	 * @param imageId Digest that points to the built image
+	 * @param layers Intermediate layers used by the build, can be used for GC.
+	 * The last id in the layers array is also the imageId, so care should be
+	 * taken to not GC the built image.
 	 */
-	buildSuccess?: (imageId: string, layers: string[]) => void
+	buildSuccess?: (imageId: string, layers: string[]) => void;
 
 	/**
 	 * This hook will be called upon build failure, with the error that caused
 	 * the failure.
 	 *
-	 * @param {Error} error
-	 *	The error which caused the build failure
-	 *
-	 * @param {string[]} layers
-	 *	The layer which were successful
+	 * @param error Error that caused the build failure
+	 * @param layers The layers that were successful
 	 */
-	buildFailure?: (error: Error, layers: string[]) => void
+	buildFailure?: (error: Error, layers: string[]) => void;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,57 +1,71 @@
-import * as Promise from 'bluebird'
-import * as klaw from 'klaw'
+/**
+ * @license
+ * Copyright 2019 Balena Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as Bluebird from 'bluebird';
+import * as klaw from 'klaw';
 
 /**
  * Given a docker 'arrow message' containing a sha representing
  * a layer, extract the sha digest. If the string passed in is not
  * an arrow message, undefined will be returned.
  *
- * @param {string} message
- *	The build message to parse
- * @returns {string}
- *	Either the sha string, or undefined
+ * @param message The build message to parse
+ * @returns Either the sha string, or undefined
  */
 export const extractLayer = (message: string): string | undefined => {
-	const extract = extractArrowMessage(message)
+	const extract = extractArrowMessage(message);
 	if (extract !== undefined) {
-		const shaRegex = /^([a-f0-9]{12}[a-f0-9]*)/g
-		const match = shaRegex.exec(extract)
+		const shaRegex = /^([a-f0-9]{12}[a-f0-9]*)/g;
+		const match = shaRegex.exec(extract);
 		if (match) {
-			return match[1]
+			return match[1];
 		}
 	}
 
-	return
-}
+	return;
+};
 
 const extractArrowMessage = (message: string): string | undefined => {
-	const arrowTest = /^\s*-+>\s*(.+)/
-	const match = arrowTest.exec(message)
+	const arrowTest = /^\s*-+>\s*(.+)/;
+	const match = arrowTest.exec(message);
 	if (match) {
-		return match[1]
+		return match[1];
 	} else {
-		return
+		return;
 	}
-}
+};
 
 /**
  * Go through an entire directory, splitting the entries out
  * into a list of paths to work through.
  */
-export const directoryToFiles = (dirPath: string): Promise<string[]> => {
-	return new Promise<string[]>((resolve, reject) => {
-		const files: string[] = []
+export const directoryToFiles = (dirPath: string): Bluebird<string[]> => {
+	return new Bluebird<string[]>((resolve, reject) => {
+		const files: string[] = [];
 
 		// Walk the directory
 		klaw(dirPath)
-		.on('data', (item: klaw.Item) => {
-			if (!item.stats.isDirectory()) {
-				files.push(item.path)
-			}
-		})
-		.on('end', () => {
-			resolve(files)
-		})
-		.on('error', reject)
-	})
-}
+			.on('data', (item: klaw.Item) => {
+				if (!item.stats.isDirectory()) {
+					files.push(item.path);
+				}
+			})
+			.on('end', () => {
+				resolve(files);
+			})
+			.on('error', reject);
+	});
+};

--- a/test/test-files/sample_daemon_output.ts
+++ b/test/test-files/sample_daemon_output.ts
@@ -27,181 +27,211 @@ export const sampleDaemonOutput = [
 	{
 		status: 'Downloading',
 		progressDetail: { current: 21176, total: 2034577 },
-		progress: '[>                                                  ]  21.18kB/2.035MB',
+		progress:
+			'[>                                                  ]  21.18kB/2.035MB',
 		id: 'ad0eac849f8f',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 25139, total: 2387846 },
-		progress: '[>                                                  ]  25.14kB/2.388MB',
+		progress:
+			'[>                                                  ]  25.14kB/2.388MB',
 		id: 'd6a5679aa3cf',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 302398, total: 2034577 },
-		progress: '[=======>                                           ]  302.4kB/2.035MB',
+		progress:
+			'[=======>                                           ]  302.4kB/2.035MB',
 		id: 'ad0eac849f8f',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 127035, total: 2387846 },
-		progress: '[==>                                                ]    127kB/2.388MB',
+		progress:
+			'[==>                                                ]    127kB/2.388MB',
 		id: 'd6a5679aa3cf',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 63627, total: 6265380 },
-		progress: '[>                                                  ]  63.63kB/6.265MB',
+		progress:
+			'[>                                                  ]  63.63kB/6.265MB',
 		id: '2261ba058a15',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 564542, total: 2034577 },
-		progress: '[=============>                                     ]  564.5kB/2.035MB',
+		progress:
+			'[=============>                                     ]  564.5kB/2.035MB',
 		id: 'ad0eac849f8f',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 228504, total: 2387846 },
-		progress: '[====>                                              ]  228.5kB/2.388MB',
+		progress:
+			'[====>                                              ]  228.5kB/2.388MB',
 		id: 'd6a5679aa3cf',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 192571, total: 6265380 },
-		progress: '[=>                                                 ]  192.6kB/6.265MB',
+		progress:
+			'[=>                                                 ]  192.6kB/6.265MB',
 		id: '2261ba058a15',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 817932, total: 2034577 },
-		progress: '[====================>                              ]  817.9kB/2.035MB',
+		progress:
+			'[====================>                              ]  817.9kB/2.035MB',
 		id: 'ad0eac849f8f',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 359164, total: 2387846 },
-		progress: '[=======>                                           ]  359.2kB/2.388MB',
+		progress:
+			'[=======>                                           ]  359.2kB/2.388MB',
 		id: 'd6a5679aa3cf',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 326808, total: 6265380 },
-		progress: '[==>                                                ]  326.8kB/6.265MB',
+		progress:
+			'[==>                                                ]  326.8kB/6.265MB',
 		id: '2261ba058a15',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 1014540, total: 2034577 },
-		progress: '[========================>                          ]  1.015MB/2.035MB',
+		progress:
+			'[========================>                          ]  1.015MB/2.035MB',
 		id: 'ad0eac849f8f',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 473852, total: 2387846 },
-		progress: '[=========>                                         ]  473.9kB/2.388MB',
+		progress:
+			'[=========>                                         ]  473.9kB/2.388MB',
 		id: 'd6a5679aa3cf',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 523416, total: 6265380 },
-		progress: '[====>                                              ]  523.4kB/6.265MB',
+		progress:
+			'[====>                                              ]  523.4kB/6.265MB',
 		id: '2261ba058a15',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 1178380, total: 2034577 },
-		progress: '[============================>                      ]  1.178MB/2.035MB',
+		progress:
+			'[============================>                      ]  1.178MB/2.035MB',
 		id: 'ad0eac849f8f',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 720024, total: 6265380 },
-		progress: '[=====>                                             ]    720kB/6.265MB',
+		progress:
+			'[=====>                                             ]    720kB/6.265MB',
 		id: '2261ba058a15',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 576252, total: 2387846 },
-		progress: '[============>                                      ]  576.3kB/2.388MB',
+		progress:
+			'[============>                                      ]  576.3kB/2.388MB',
 		id: 'd6a5679aa3cf',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 1342220, total: 2034577 },
-		progress: '[================================>                  ]  1.342MB/2.035MB',
+		progress:
+			'[================================>                  ]  1.342MB/2.035MB',
 		id: 'ad0eac849f8f',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 916240, total: 6265380 },
-		progress: '[=======>                                           ]  916.2kB/6.265MB',
+		progress:
+			'[=======>                                           ]  916.2kB/6.265MB',
 		id: '2261ba058a15',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 703228, total: 2387846 },
-		progress: '[==============>                                    ]  703.2kB/2.388MB',
+		progress:
+			'[==============>                                    ]  703.2kB/2.388MB',
 		id: 'd6a5679aa3cf',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 1538828, total: 2034577 },
-		progress: '[=====================================>             ]  1.539MB/2.035MB',
+		progress:
+			'[=====================================>             ]  1.539MB/2.035MB',
 		id: 'ad0eac849f8f',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 801532, total: 2387846 },
-		progress: '[================>                                  ]  801.5kB/2.388MB',
+		progress:
+			'[================>                                  ]  801.5kB/2.388MB',
 		id: 'd6a5679aa3cf',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 1141520, total: 6265380 },
-		progress: '[=========>                                         ]  1.142MB/6.265MB',
+		progress:
+			'[=========>                                         ]  1.142MB/6.265MB',
 		id: '2261ba058a15',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 1702668, total: 2034577 },
-		progress: '[=========================================>         ]  1.703MB/2.035MB',
+		progress:
+			'[=========================================>         ]  1.703MB/2.035MB',
 		id: 'ad0eac849f8f',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 899836, total: 2387846 },
-		progress: '[==================>                                ]  899.8kB/2.388MB',
+		progress:
+			'[==================>                                ]  899.8kB/2.388MB',
 		id: 'd6a5679aa3cf',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 1833740, total: 2034577 },
-		progress: '[=============================================>     ]  1.834MB/2.035MB',
+		progress:
+			'[=============================================>     ]  1.834MB/2.035MB',
 		id: 'ad0eac849f8f',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 1350416, total: 6265380 },
-		progress: '[==========>                                        ]   1.35MB/6.265MB',
+		progress:
+			'[==========>                                        ]   1.35MB/6.265MB',
 		id: '2261ba058a15',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 932604, total: 2387846 },
-		progress: '[===================>                               ]  932.6kB/2.388MB',
+		progress:
+			'[===================>                               ]  932.6kB/2.388MB',
 		id: 'd6a5679aa3cf',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 1932044, total: 2034577 },
-		progress: '[===============================================>   ]  1.932MB/2.035MB',
+		progress:
+			'[===============================================>   ]  1.932MB/2.035MB',
 		id: 'ad0eac849f8f',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 1555216, total: 6265380 },
-		progress: '[============>                                      ]  1.555MB/6.265MB',
+		progress:
+			'[============>                                      ]  1.555MB/6.265MB',
 		id: '2261ba058a15',
 	},
 	{ status: 'Verifying Checksum', progressDetail: {}, id: 'ad0eac849f8f' },
@@ -209,73 +239,85 @@ export const sampleDaemonOutput = [
 	{
 		status: 'Downloading',
 		progressDetail: { current: 1030908, total: 2387846 },
-		progress: '[=====================>                             ]  1.031MB/2.388MB',
+		progress:
+			'[=====================>                             ]  1.031MB/2.388MB',
 		id: 'd6a5679aa3cf',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 1817360, total: 6265380 },
-		progress: '[==============>                                    ]  1.817MB/6.265MB',
+		progress:
+			'[==============>                                    ]  1.817MB/6.265MB',
 		id: '2261ba058a15',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 1174268, total: 2387846 },
-		progress: '[========================>                          ]  1.174MB/2.388MB',
+		progress:
+			'[========================>                          ]  1.174MB/2.388MB',
 		id: 'd6a5679aa3cf',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 2087696, total: 6265380 },
-		progress: '[================>                                  ]  2.088MB/6.265MB',
+		progress:
+			'[================>                                  ]  2.088MB/6.265MB',
 		id: '2261ba058a15',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 1293052, total: 2387846 },
-		progress: '[===========================>                       ]  1.293MB/2.388MB',
+		progress:
+			'[===========================>                       ]  1.293MB/2.388MB',
 		id: 'd6a5679aa3cf',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 2370320, total: 6265380 },
-		progress: '[==================>                                ]   2.37MB/6.265MB',
+		progress:
+			'[==================>                                ]   2.37MB/6.265MB',
 		id: '2261ba058a15',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 1424124, total: 2387846 },
-		progress: '[=============================>                     ]  1.424MB/2.388MB',
+		progress:
+			'[=============================>                     ]  1.424MB/2.388MB',
 		id: 'd6a5679aa3cf',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 2702096, total: 6265380 },
-		progress: '[=====================>                             ]  2.702MB/6.265MB',
+		progress:
+			'[=====================>                             ]  2.702MB/6.265MB',
 		id: '2261ba058a15',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 1555196, total: 2387846 },
-		progress: '[================================>                  ]  1.555MB/2.388MB',
+		progress:
+			'[================================>                  ]  1.555MB/2.388MB',
 		id: 'd6a5679aa3cf',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 3029776, total: 6265380 },
-		progress: '[========================>                          ]   3.03MB/6.265MB',
+		progress:
+			'[========================>                          ]   3.03MB/6.265MB',
 		id: '2261ba058a15',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 1678076, total: 2387846 },
-		progress: '[===================================>               ]  1.678MB/2.388MB',
+		progress:
+			'[===================================>               ]  1.678MB/2.388MB',
 		id: 'd6a5679aa3cf',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 369, total: 369 },
-		progress: '[==================================================>]     369B/369B',
+		progress:
+			'[==================================================>]     369B/369B',
 		id: 'f296fda86f10',
 	},
 	{ status: 'Verifying Checksum', progressDetail: {}, id: 'f296fda86f10' },
@@ -283,67 +325,78 @@ export const sampleDaemonOutput = [
 	{
 		status: 'Downloading',
 		progressDetail: { current: 3357456, total: 6265380 },
-		progress: '[==========================>                        ]  3.357MB/6.265MB',
+		progress:
+			'[==========================>                        ]  3.357MB/6.265MB',
 		id: '2261ba058a15',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 1809148, total: 2387846 },
-		progress: '[=====================================>             ]  1.809MB/2.388MB',
+		progress:
+			'[=====================================>             ]  1.809MB/2.388MB',
 		id: 'd6a5679aa3cf',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 3685136, total: 6265380 },
-		progress: '[=============================>                     ]  3.685MB/6.265MB',
+		progress:
+			'[=============================>                     ]  3.685MB/6.265MB',
 		id: '2261ba058a15',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 1927932, total: 2387846 },
-		progress: '[========================================>          ]  1.928MB/2.388MB',
+		progress:
+			'[========================================>          ]  1.928MB/2.388MB',
 		id: 'd6a5679aa3cf',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 4012816, total: 6265380 },
-		progress: '[================================>                  ]  4.013MB/6.265MB',
+		progress:
+			'[================================>                  ]  4.013MB/6.265MB',
 		id: '2261ba058a15',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 2050812, total: 2387846 },
-		progress: '[==========================================>        ]  2.051MB/2.388MB',
+		progress:
+			'[==========================================>        ]  2.051MB/2.388MB',
 		id: 'd6a5679aa3cf',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 4340496, total: 6265380 },
-		progress: '[==================================>                ]   4.34MB/6.265MB',
+		progress:
+			'[==================================>                ]   4.34MB/6.265MB',
 		id: '2261ba058a15',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 2181884, total: 2387846 },
-		progress: '[=============================================>     ]  2.182MB/2.388MB',
+		progress:
+			'[=============================================>     ]  2.182MB/2.388MB',
 		id: 'd6a5679aa3cf',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 4668176, total: 6265380 },
-		progress: '[=====================================>             ]  4.668MB/6.265MB',
+		progress:
+			'[=====================================>             ]  4.668MB/6.265MB',
 		id: '2261ba058a15',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 2312956, total: 2387846 },
-		progress: '[================================================>  ]  2.313MB/2.388MB',
+		progress:
+			'[================================================>  ]  2.313MB/2.388MB',
 		id: 'd6a5679aa3cf',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 212, total: 212 },
-		progress: '[==================================================>]     212B/212B',
+		progress:
+			'[==================================================>]     212B/212B',
 		id: 'bcd4a541795b',
 	},
 	{ status: 'Verifying Checksum', progressDetail: {}, id: 'bcd4a541795b' },
@@ -353,62 +406,72 @@ export const sampleDaemonOutput = [
 	{
 		status: 'Extracting',
 		progressDetail: { current: 32768, total: 2387846 },
-		progress: '[>                                                  ]  32.77kB/2.388MB',
+		progress:
+			'[>                                                  ]  32.77kB/2.388MB',
 		id: 'd6a5679aa3cf',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 4995856, total: 6265380 },
-		progress: '[=======================================>           ]  4.996MB/6.265MB',
+		progress:
+			'[=======================================>           ]  4.996MB/6.265MB',
 		id: '2261ba058a15',
 	},
 	{
 		status: 'Extracting',
 		progressDetail: { current: 983040, total: 2387846 },
-		progress: '[====================>                              ]    983kB/2.388MB',
+		progress:
+			'[====================>                              ]    983kB/2.388MB',
 		id: 'd6a5679aa3cf',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 5389072, total: 6265380 },
-		progress: '[===========================================>       ]  5.389MB/6.265MB',
+		progress:
+			'[===========================================>       ]  5.389MB/6.265MB',
 		id: '2261ba058a15',
 	},
 	{
 		status: 'Extracting',
 		progressDetail: { current: 2387846, total: 2387846 },
-		progress: '[==================================================>]  2.388MB/2.388MB',
+		progress:
+			'[==================================================>]  2.388MB/2.388MB',
 		id: 'd6a5679aa3cf',
 	},
 	{
 		status: 'Extracting',
 		progressDetail: { current: 2387846, total: 2387846 },
-		progress: '[==================================================>]  2.388MB/2.388MB',
+		progress:
+			'[==================================================>]  2.388MB/2.388MB',
 		id: 'd6a5679aa3cf',
 	},
 	{ status: 'Pull complete', progressDetail: {}, id: 'd6a5679aa3cf' },
 	{
 		status: 'Extracting',
 		progressDetail: { current: 32768, total: 2034577 },
-		progress: '[>                                                  ]  32.77kB/2.035MB',
+		progress:
+			'[>                                                  ]  32.77kB/2.035MB',
 		id: 'ad0eac849f8f',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 5782288, total: 6265380 },
-		progress: '[==============================================>    ]  5.782MB/6.265MB',
+		progress:
+			'[==============================================>    ]  5.782MB/6.265MB',
 		id: '2261ba058a15',
 	},
 	{
 		status: 'Extracting',
 		progressDetail: { current: 425984, total: 2034577 },
-		progress: '[==========>                                        ]    426kB/2.035MB',
+		progress:
+			'[==========>                                        ]    426kB/2.035MB',
 		id: 'ad0eac849f8f',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 6241040, total: 6265380 },
-		progress: '[=================================================> ]  6.241MB/6.265MB',
+		progress:
+			'[=================================================> ]  6.241MB/6.265MB',
 		id: '2261ba058a15',
 	},
 	{ status: 'Verifying Checksum', progressDetail: {}, id: '2261ba058a15' },
@@ -416,75 +479,87 @@ export const sampleDaemonOutput = [
 	{
 		status: 'Extracting',
 		progressDetail: { current: 1802240, total: 2034577 },
-		progress: '[============================================>      ]  1.802MB/2.035MB',
+		progress:
+			'[============================================>      ]  1.802MB/2.035MB',
 		id: 'ad0eac849f8f',
 	},
 	{
 		status: 'Extracting',
 		progressDetail: { current: 1998848, total: 2034577 },
-		progress: '[=================================================> ]  1.999MB/2.035MB',
+		progress:
+			'[=================================================> ]  1.999MB/2.035MB',
 		id: 'ad0eac849f8f',
 	},
 	{
 		status: 'Extracting',
 		progressDetail: { current: 2034577, total: 2034577 },
-		progress: '[==================================================>]  2.035MB/2.035MB',
+		progress:
+			'[==================================================>]  2.035MB/2.035MB',
 		id: 'ad0eac849f8f',
 	},
 	{ status: 'Pull complete', progressDetail: {}, id: 'ad0eac849f8f' },
 	{
 		status: 'Extracting',
 		progressDetail: { current: 65536, total: 6265380 },
-		progress: '[>                                                  ]  65.54kB/6.265MB',
+		progress:
+			'[>                                                  ]  65.54kB/6.265MB',
 		id: '2261ba058a15',
 	},
 	{
 		status: 'Extracting',
 		progressDetail: { current: 1703936, total: 6265380 },
-		progress: '[=============>                                     ]  1.704MB/6.265MB',
+		progress:
+			'[=============>                                     ]  1.704MB/6.265MB',
 		id: '2261ba058a15',
 	},
 	{
 		status: 'Extracting',
 		progressDetail: { current: 4194304, total: 6265380 },
-		progress: '[=================================>                 ]  4.194MB/6.265MB',
+		progress:
+			'[=================================>                 ]  4.194MB/6.265MB',
 		id: '2261ba058a15',
 	},
 	{
 		status: 'Extracting',
 		progressDetail: { current: 6265380, total: 6265380 },
-		progress: '[==================================================>]  6.265MB/6.265MB',
+		progress:
+			'[==================================================>]  6.265MB/6.265MB',
 		id: '2261ba058a15',
 	},
 	{ status: 'Pull complete', progressDetail: {}, id: '2261ba058a15' },
 	{
 		status: 'Extracting',
 		progressDetail: { current: 369, total: 369 },
-		progress: '[==================================================>]     369B/369B',
+		progress:
+			'[==================================================>]     369B/369B',
 		id: 'f296fda86f10',
 	},
 	{
 		status: 'Extracting',
 		progressDetail: { current: 369, total: 369 },
-		progress: '[==================================================>]     369B/369B',
+		progress:
+			'[==================================================>]     369B/369B',
 		id: 'f296fda86f10',
 	},
 	{ status: 'Pull complete', progressDetail: {}, id: 'f296fda86f10' },
 	{
 		status: 'Extracting',
 		progressDetail: { current: 212, total: 212 },
-		progress: '[==================================================>]     212B/212B',
+		progress:
+			'[==================================================>]     212B/212B',
 		id: 'bcd4a541795b',
 	},
 	{
 		status: 'Extracting',
 		progressDetail: { current: 212, total: 212 },
-		progress: '[==================================================>]     212B/212B',
+		progress:
+			'[==================================================>]     212B/212B',
 		id: 'bcd4a541795b',
 	},
 	{ status: 'Pull complete', progressDetail: {}, id: 'bcd4a541795b' },
 	{
-		status: 'Digest: sha256:5a156ff125e5a12ac7fdec2b90b7e2ae5120fa249cf62248337b6d04abc574c8',
+		status:
+			'Digest: sha256:5a156ff125e5a12ac7fdec2b90b7e2ae5120fa249cf62248337b6d04abc574c8',
 	},
 	{ status: 'Status: Downloaded newer image for registry:2' },
 	{ stream: ' ---> 2e2f252f3c88\n' },
@@ -522,19 +597,22 @@ export const sampleDaemonOutput = [
 	{
 		status: 'Downloading',
 		progressDetail: { current: 8214, total: 727978 },
-		progress: '[>                                                  ]  8.214kB/728kB',
+		progress:
+			'[>                                                  ]  8.214kB/728kB',
 		id: '90e01955edcd',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 404239, total: 727978 },
-		progress: '[===========================>                       ]  404.2kB/728kB',
+		progress:
+			'[===========================>                       ]  404.2kB/728kB',
 		id: '90e01955edcd',
 	},
 	{
 		status: 'Downloading',
 		progressDetail: { current: 727978, total: 727978 },
-		progress: '[==================================================>]    728kB/728kB',
+		progress:
+			'[==================================================>]    728kB/728kB',
 		id: '90e01955edcd',
 	},
 	{ status: 'Verifying Checksum', progressDetail: {}, id: '90e01955edcd' },
@@ -542,18 +620,21 @@ export const sampleDaemonOutput = [
 	{
 		status: 'Extracting',
 		progressDetail: { current: 32768, total: 727978 },
-		progress: '[==>                                                ]  32.77kB/728kB',
+		progress:
+			'[==>                                                ]  32.77kB/728kB',
 		id: '90e01955edcd',
 	},
 	{
 		status: 'Extracting',
 		progressDetail: { current: 727978, total: 727978 },
-		progress: '[==================================================>]    728kB/728kB',
+		progress:
+			'[==================================================>]    728kB/728kB',
 		id: '90e01955edcd',
 	},
 	{ status: 'Pull complete', progressDetail: {}, id: '90e01955edcd' },
 	{
-		status: 'Digest: sha256:2a03a6059f21e150ae84b0973863609494aad70f0a80eaeb64bddd8d92465812',
+		status:
+			'Digest: sha256:2a03a6059f21e150ae84b0973863609494aad70f0a80eaeb64bddd8d92465812',
 	},
 	{ status: 'Status: Downloaded newer image for busybox:latest' },
 	{ status: 'The push refers to a repository [127.0.0.1:55055/busybox]' },
@@ -561,7 +642,8 @@ export const sampleDaemonOutput = [
 	{
 		status: 'Pushing',
 		progressDetail: { current: 33792, total: 1154353 },
-		progress: '[=>                                                 ]  33.79kB/1.154MB',
+		progress:
+			'[=>                                                 ]  33.79kB/1.154MB',
 		id: '8a788232037e',
 	},
 	{
@@ -579,7 +661,8 @@ export const sampleDaemonOutput = [
 		progressDetail: {},
 		aux: {
 			Tag: 'latest',
-			Digest: 'sha256:e2d9acbe92a6def141a9f9f2584468206735308df6a696430e25947882385fb2',
+			Digest:
+				'sha256:e2d9acbe92a6def141a9f9f2584468206735308df6a696430e25947882385fb2',
 			Size: 527,
 		},
 	},
@@ -591,8 +674,8 @@ export function* sampleDaemonOutputGenerator(): IterableIterator<string> {
 	}
 }
 
-export function* sampleDaemonStreamGenerator(): IterableIterator<string> {    
-    for (const step of sampleDaemonOutput.filter((step) => step.stream)) {
-        yield step.stream!;
+export function* sampleDaemonStreamGenerator(): IterableIterator<string> {
+	for (const step of sampleDaemonOutput.filter(stepp => stepp.stream)) {
+		yield step.stream!;
 	}
 }

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,23 +1,41 @@
-import 'mocha'
-import * as Bluebird from 'bluebird'
-import * as Dockerode from 'dockerode'
-import * as url from 'url';
-import * as fs from 'fs'
-import * as path from 'path'
+/**
+ * @license
+ * Copyright 2019 Balena Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import 'mocha';
 
-import Builder from '../src/index'
-import { BuildHooks } from '../src/plugin'
+import * as Bluebird from 'bluebird';
+import * as Dockerode from 'dockerode';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as url from 'url';
+
+import Builder from '../src/index';
+import { BuildHooks } from '../src/plugin';
 
 // In general we don't want output, until we do.
 // call with `env DISPLAY_TEST_OUTPUT=1 npm test` to display output
-const displayOutput = process.env.DISPLAY_TEST_OUTPUT === '1'
+const displayOutput = process.env.DISPLAY_TEST_OUTPUT === '1';
 
 let dockerOpts: Dockerode.DockerOptions;
 if (process.env.CIRCLECI != null) {
-
-	const certs = ['ca.pem', 'cert.pem', 'key.pem'].map((f) => path.join(process.env.DOCKER_CERT_PATH!, f));
-	const [ca, cert, key ] = certs.map((c) => fs.readFileSync(c));
-	let parsed = url.parse(process.env.DOCKER_HOST!);
+	const certs = ['ca.pem', 'cert.pem', 'key.pem'].map(f =>
+		path.join(process.env.DOCKER_CERT_PATH!, f),
+	);
+	const [ca, cert, key] = certs.map(c => fs.readFileSync(c));
+	const parsed = url.parse(process.env.DOCKER_HOST!);
 
 	dockerOpts = {
 		host: 'https://' + parsed.hostname,
@@ -36,232 +54,233 @@ const docker = new Dockerode(dockerOpts);
 // define them here to make it slightly easier
 //
 // sucessHooks: for when we want the buildSuccess hook to be called
-const getSuccessHooks = (done: Function): BuildHooks => {
+const getSuccessHooks = (done: (error?: Error) => void): BuildHooks => {
 	const hooks: BuildHooks = {
 		buildSuccess: (id, layers) => {
-			done()
+			done();
 		},
-		buildFailure: (err) => {
+		buildFailure: err => {
 			if (displayOutput) {
-				console.log(err)
+				console.log(err);
 			}
-			done(err)
-		}
-	}
-	return hooks
-}
+			done(err);
+		},
+	};
+	return hooks;
+};
 // failureHooks: for when we want the failure hook to be called
-const getFailureHooks = (done: Function): BuildHooks => {
+const getFailureHooks = (done: (error?: Error) => void): BuildHooks => {
 	const hooks: BuildHooks = {
 		buildSuccess: (id, layers) => {
-			done(new Error('Expected error, got success'))
+			done(new Error('Expected error, got success'));
 		},
-		buildFailure: (err) => {
+		buildFailure: err => {
 			if (displayOutput) {
-				console.log(err)
+				console.log(err);
 			}
-			done()
-		}
-	}
-	return hooks
-}
+			done();
+		},
+	};
+	return hooks;
+};
 
 describe('Directory build', () => {
 	it('should build a directory image', function(done) {
 		// Give the build 60 seconds to finish
-		this.timeout(60000)
+		this.timeout(60000);
 		// Start a directory build
 		const builder = Builder.fromDockerode(docker);
-		const hooks = getSuccessHooks(done)
+		const hooks = getSuccessHooks(done);
 
-		builder.buildDir('test/test-files/directory-successful-build', {}, hooks)
-		.then((stream) => {
-			if (displayOutput) {
-				stream.pipe(process.stdout)
-			}
-		})
-	})
+		builder
+			.buildDir('test/test-files/directory-successful-build', {}, hooks)
+			.then(stream => {
+				if (displayOutput) {
+					stream.pipe(process.stdout);
+				}
+			});
+	});
 
 	it('should fail to build a directory without Dockerfile', function(done) {
-		this.timeout(30000)
+		this.timeout(30000);
 
 		const builder = Builder.fromDockerode(docker);
-		const hooks = getFailureHooks(done)
+		const hooks = getFailureHooks(done);
 
-		builder.buildDir('test/test-files/directory-no-dockerfile', {}, hooks)
-		.then((stream) => {
-			if (displayOutput) {
-				stream.pipe(process.stdout)
-			}
-		})
-
-	})
+		builder
+			.buildDir('test/test-files/directory-no-dockerfile', {}, hooks)
+			.then(stream => {
+				if (displayOutput) {
+					stream.pipe(process.stdout);
+				}
+			});
+	});
 
 	it('should fail with invalid Dockerfile', function(done) {
-		this.timeout(30000)
+		this.timeout(30000);
 
 		const builder = Builder.fromDockerode(docker);
-		const hooks = getFailureHooks(done)
+		const hooks = getFailureHooks(done);
 
-		builder.buildDir('test/test-files/directory-invalid-dockerfile', {}, hooks)
-		.then((stream) => {
-			if (displayOutput) {
-				stream.pipe(process.stdout)
-			}
-		})
-	})
+		builder
+			.buildDir('test/test-files/directory-invalid-dockerfile', {}, hooks)
+			.then(stream => {
+				if (displayOutput) {
+					stream.pipe(process.stdout);
+				}
+			});
+	});
 
 	it('should pass stream to caller on successful build', function(done) {
 		// Shorter timeout for this test, as a timeout is the failure marker
-		this.timeout(10000)
+		this.timeout(10000);
 		const hooks: BuildHooks = {
-			buildStream: (stream) => {
+			buildStream: stream => {
 				if (displayOutput) {
-					stream.pipe(process.stdout)
+					stream.pipe(process.stdout);
 				}
-				done()
-			}
-		}
+				done();
+			},
+		};
 
 		const builder = Builder.fromDockerode(docker);
-		builder.buildDir('test/test-files/directory-successful-build', {}, hooks)
-
-	})
+		builder.buildDir('test/test-files/directory-successful-build', {}, hooks);
+	});
 
 	it('should pass stream to caller on unsuccessful build', function(done) {
-		this.timeout(10000)
+		this.timeout(10000);
 		const hooks: BuildHooks = {
-			buildStream: (stream) => {
+			buildStream: stream => {
 				if (displayOutput) {
-					stream.pipe(process.stdout)
+					stream.pipe(process.stdout);
 				}
-				done()
-			}
-		}
+				done();
+			},
+		};
 
 		const builder = Builder.fromDockerode(docker);
-		builder.buildDir('test/test-files/directory-invalid-dockerfile', {}, hooks)
-
-	})
-})
+		builder.buildDir('test/test-files/directory-invalid-dockerfile', {}, hooks);
+	});
+});
 
 describe('Tar stream build', () => {
 	it('should build a tar stream successfully', function(done) {
-		this.timeout(60000)
+		this.timeout(60000);
 
-		const tarStream = fs.createReadStream('test/test-files/archives/success.tar')
+		const tarStream = fs.createReadStream(
+			'test/test-files/archives/success.tar',
+		);
 
 		const hooks: BuildHooks = {
-			buildStream: (stream) => {
-				tarStream.pipe(stream)
+			buildStream: stream => {
+				tarStream.pipe(stream);
 				if (displayOutput) {
-					stream.pipe(process.stdout)
+					stream.pipe(process.stdout);
 				}
 			},
 			buildSuccess: (id, layers) => {
-				done()
+				done();
 			},
-			buildFailure: (err) => {
+			buildFailure: err => {
 				if (displayOutput) {
-					console.log(err)
+					console.log(err);
 				}
-				done(err)
-			}
-		}
+				done(err);
+			},
+		};
 
 		const builder = Builder.fromDockerode(docker);
-		builder.createBuildStream({}, hooks)
-	})
+		builder.createBuildStream({}, hooks);
+	});
 
 	it('should fail to build invalid tar stream', function(done) {
-		this.timeout(60000)
+		this.timeout(60000);
 
-		const tarStream = fs.createReadStream('test/test-files/archives/failure.tar')
+		const tarStream = fs.createReadStream(
+			'test/test-files/archives/failure.tar',
+		);
 
 		const hooks: BuildHooks = {
-			buildStream: (stream) => {
-				tarStream.pipe(stream)
+			buildStream: stream => {
+				tarStream.pipe(stream);
 				if (displayOutput) {
-					stream.pipe(process.stdout)
+					stream.pipe(process.stdout);
 				}
 			},
 			buildSuccess: (id, layers) => {
-				done(new Error('Expected build failure, got success hook'))
+				done(new Error('Expected build failure, got success hook'));
 			},
-			buildFailure: (err) => {
+			buildFailure: err => {
 				if (displayOutput) {
-					console.log(err)
+					console.log(err);
 				}
-				done()
-			}
-		}
+				done();
+			},
+		};
 
 		const builder = Builder.fromDockerode(docker);
-		builder.createBuildStream({}, hooks)
-
-	})
+		builder.createBuildStream({}, hooks);
+	});
 
 	it('should return successful layers upon failure', function() {
-		this.timeout(60000)
+		this.timeout(60000);
 		return new Bluebird((resolve, reject) => {
-
-			const tarStream = fs.createReadStream('test/test-files/archives/failure-layers.tar')
+			const tarStream = fs.createReadStream(
+				'test/test-files/archives/failure-layers.tar',
+			);
 
 			const hooks: BuildHooks = {
 				buildSuccess: () => {
-					reject(new Error('Success failed on failing build'))
+					reject(new Error('Success failed on failing build'));
 				},
 				buildFailure: (error, layers) => {
 					if (layers.length !== 2) {
-						reject(new Error('Incorrect amount of layers return in error handler'))
+						reject(
+							new Error('Incorrect amount of layers return in error handler'),
+						);
 					}
-
-					resolve()
+					resolve();
 				},
-				buildStream: (stream) => {
-					tarStream.pipe(stream)
+				buildStream: stream => {
+					tarStream.pipe(stream);
 					if (displayOutput) {
-						stream.pipe(process.stdout)
+						stream.pipe(process.stdout);
 					}
-				}
-			}
+				},
+			};
 
 			const builder = Builder.fromDockerode(docker);
-			builder.createBuildStream({}, hooks)
-
-		})
-
-	})
-
-})
+			builder.createBuildStream({}, hooks);
+		});
+	});
+});
 
 describe('Error handler', () => {
 	it('should catch a synchronous error from a hook', function(done) {
 		const handler = () => {
-			done()
-		}
+			done();
+		};
 		const hooks: BuildHooks = {
-			buildStream: (stream) => {
-				throw new Error('Should be caught')
-			}
-		}
-		const builder = Builder.fromDockerode(docker)
-		builder.createBuildStream({}, hooks, handler)
-	})
-
-	it('should catch an asynchronous error from a hook', function (done) {
-		const handler = () => {
-			done()
-		}
-		const hooks: BuildHooks = {
-			buildStream: (stream) => {
-				return new Promise((resolve, reject) => {
-					reject(new Error('test'))
-				})
-			}
-		}
+			buildStream: stream => {
+				throw new Error('Should be caught');
+			},
+		};
 		const builder = Builder.fromDockerode(docker);
-		builder.createBuildStream({}, hooks, handler)
-	})
-})
+		builder.createBuildStream({}, hooks, handler);
+	});
 
+	it('should catch an asynchronous error from a hook', function(done) {
+		const handler = () => {
+			done();
+		};
+		const hooks: BuildHooks = {
+			buildStream: stream => {
+				return new Promise((resolve, reject) => {
+					reject(new Error('test'));
+				});
+			},
+		};
+		const builder = Builder.fromDockerode(docker);
+		builder.createBuildStream({}, hooks, handler);
+	});
+});

--- a/test/test_build_stream.ts
+++ b/test/test_build_stream.ts
@@ -14,16 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-import { Stream, Readable, Writable, Duplex } from 'stream';
+import { assert } from 'chai';
+import { Readable, Stream, Writable } from 'stream';
 
 import Builder from '../src/index';
 import {
 	sampleDaemonOutputGenerator,
 	sampleDaemonStreamGenerator,
 } from './test-files/sample_daemon_output';
-
-const { assert } = require('chai');
 
 /**
  * This test asserts that the createBuildStream() method writes the expected
@@ -47,18 +45,22 @@ describe('createBuildStream performance', function() {
 		let startTime: number;
 		const mockBuilder = new MockBuilder();
 		const streamer = sampleDaemonStreamGenerator();
-		const buildStream = Builder.prototype.createBuildStream.call(mockBuilder, {});
+		const buildStream = Builder.prototype.createBuildStream.call(
+			mockBuilder,
+			{},
+		);
 		const buildStreamPromise = new Promise((resolve, reject) => {
 			buildStream
 				.on('error', reject)
 				.on('end', () => {
 					console.log(
 						`createBuildStream performance test: write time (tar stream): ${
-							mockBuilder.docker.tarStreamMilliseconds} milliseconds`,
+							mockBuilder.docker.tarStreamMilliseconds
+						} milliseconds`,
 					);
 					console.log(
-						`createBuildStream performance test: read time (JSON stream): ${
-							Date.now() - startTime} milliseconds`,
+						`createBuildStream performance test: read time (JSON stream): ${Date.now() -
+							startTime} milliseconds`,
 					);
 					resolve();
 				})
@@ -76,10 +78,7 @@ describe('createBuildStream performance', function() {
 
 		// Create a mock tar stream and pipe it to the builder (buildStream)
 		const tarStreamSizeMegaBytes = 1;
-		const tarStreamPromise = mockTarStream(
-			buildStream,
-			tarStreamSizeMegaBytes,
-		);
+		const tarStreamPromise = mockTarStream(buildStream, tarStreamSizeMegaBytes);
 
 		await Promise.all([
 			tarStreamPromise,
@@ -193,5 +192,7 @@ class MockBuilder {
 		this.docker = new MockDockerode();
 	}
 
-	private callHook() {}
+	private callHook() {
+		return;
+	}
 }

--- a/typings/JSONStream/index.d.ts
+++ b/typings/JSONStream/index.d.ts
@@ -14,8 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Builder from './builder';
-import { BuildHooks } from './plugin';
 
-export default Builder;
-export { Builder, BuildHooks };
+/**
+ * There is a `@types/jsonstream` package, but the version of the typescript
+ * compiler used by CircleCI makes a distinction between uppercase 'JSONStream'
+ * and lowercase 'jsonstream'.
+ *
+ * TODO: create a pull request for github.com/DefinitelyTyped/DefinitelyTyped
+ * for the uppercase 'JSONStream' style, which is the official capitalisation
+ * according to the project's website.
+ */
+declare module 'JSONStream' {
+	function parse(pattern?: any): NodeJS.ReadWriteStream;
+}

--- a/typings/duplexify/index.d.ts
+++ b/typings/duplexify/index.d.ts
@@ -14,8 +14,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Builder from './builder';
-import { BuildHooks } from './plugin';
 
-export default Builder;
-export { Builder, BuildHooks };
+import * as duplexify from 'duplexify';
+import * as stream from 'stream';
+
+/**
+ * Additional typing information that is merged with that available in the npm
+ * package `@types/duplexify`.
+ * TODO: create a pull request for github.com/DefinitelyTyped/DefinitelyTyped
+ */
+declare module 'duplexify' {
+	interface Duplexify extends stream.Duplex {
+		destroy(error?: Error): void;
+	}
+}

--- a/typings/event-stream/index.d.ts
+++ b/typings/event-stream/index.d.ts
@@ -14,8 +14,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Builder from './builder';
-import { BuildHooks } from './plugin';
 
-export default Builder;
-export { Builder, BuildHooks };
+import * as es from 'event-stream';
+import { Stream } from 'stream';
+
+/**
+ * Additional typing information that is merged with that available in the npm
+ * package `@types/event-stream`.
+ * TODO: create a pull request for github.com/DefinitelyTyped/DefinitelyTyped
+ */
+declare module 'event-stream' {
+	function through<T extends Stream>(
+		write?: (data: any) => void,
+		end?: () => void,
+	): T;
+}


### PR DESCRIPTION
See issue description for this PR's main objective: #30 

Note that there are 2 commits: the first integrates resin-lint, runs prettier and adds some typescript data typing, so a large amount of changes but pretty harmless. The second commit actually changes / improves error handling in createBuildStream.

Some tests were added / modified to this module, and also tests were run in `resin-multibuild` and `resin-builder` to confirm that the changes have not broken anything.