### PR TITLE
Provide info about used base images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,12 +11,6 @@ buildSteps: &buildSteps
       command: npm test
 
 jobs:
-  "node-6":
-    docker:
-      - image: circleci/node:6
-    working_directory: ~/node-6
-    steps: *buildSteps
-
   "node-8":
     docker:
       - image: circleci/node:8
@@ -29,10 +23,16 @@ jobs:
     working_directory: ~/node-10
     steps: *buildSteps
 
+  "node-12":
+    docker:
+      - image: circleci/node:12
+    working_directory: ~/node-12
+    steps: *buildSteps
+
 workflows:
   version: 2
   build:
     jobs:
-      - "node-6"
       - "node-8"
       - "node-10"
+      - "node-12"

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -21,6 +21,12 @@
  */
 export type ValidHook = 'buildStream' | 'buildSuccess' | 'buildFailure';
 
+/** FromTagInfo: Information about an image tag referred in the Dockerfile. */
+export interface FromTagInfo {
+	repo: string;
+	tag: string;
+}
+
 /**
  * BuildHooks
  *
@@ -56,8 +62,13 @@ export interface BuildHooks {
 	 * @param layers Intermediate layers used by the build, can be used for GC.
 	 * The last id in the layers array is also the imageId, so care should be
 	 * taken to not GC the built image.
+	 * @param fromTags image tags referred during the build
 	 */
-	buildSuccess?: (imageId: string, layers: string[]) => void;
+	buildSuccess?: (
+		imageId: string,
+		layers: string[],
+		fromTags: FromTagInfo[],
+	) => void;
 
 	/**
 	 * This hook will be called upon build failure, with the error that caused
@@ -66,5 +77,9 @@ export interface BuildHooks {
 	 * @param error Error that caused the build failure
 	 * @param layers The layers that were successful
 	 */
-	buildFailure?: (error: Error, layers: string[]) => void;
+	buildFailure?: (
+		error: Error,
+		layers: string[],
+		fromTags: FromTagInfo[],
+	) => void;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,6 +17,8 @@
 import * as Bluebird from 'bluebird';
 import * as klaw from 'klaw';
 
+import * as Plugin from './plugin';
+
 /**
  * Given a docker 'arrow message' containing a sha representing
  * a layer, extract the sha digest. If the string passed in is not
@@ -68,4 +70,25 @@ export const directoryToFiles = (dirPath: string): Bluebird<string[]> => {
 			})
 			.on('error', reject);
 	});
+};
+
+const fromTagPattern = /^(Step.+?\s*:\s*)?FROM\s+([\w-./]+)(:?([\w-./]+))?\s*(as\s+([\w-./]+))?/;
+
+export interface FromTagInfo extends Plugin.FromTagInfo {
+	alias?: string;
+}
+
+export const extractFromTag = (message: string): FromTagInfo | undefined => {
+	const match = fromTagPattern.exec(message);
+	if (!match) {
+		return undefined;
+	}
+	const res: FromTagInfo = {
+		repo: match[2],
+		tag: match[4] || 'latest',
+	};
+	if (match[6]) {
+		res.alias = match[6];
+	}
+	return res;
 };

--- a/test/test.ts
+++ b/test/test.ts
@@ -105,6 +105,48 @@ describe('Directory build', () => {
 			});
 	});
 
+	it('should pass layers and FROM tags', function(done) {
+		this.timeout(60000);
+
+		const hooks: BuildHooks = {
+			buildSuccess: (id, layers, fromTags) => {
+				if (layers.length !== 4) {
+					done(new Error(`Expected 4 layers but got ${layers}`));
+					return;
+				}
+				const [from] = fromTags;
+				if (
+					fromTags.length !== 1 ||
+					from.repo !== 'debian' ||
+					from.tag !== 'jessie'
+				) {
+					done(
+						new Error(
+							`Expected info about FROM debian:jessie, but got ${fromTags}`,
+						),
+					);
+					return;
+				}
+				done();
+			},
+			buildFailure: err => {
+				if (displayOutput) {
+					console.log(err);
+				}
+				done(err);
+			},
+		};
+
+		const builder = Builder.fromDockerode(docker);
+		builder
+			.buildDir('test/test-files/directory-successful-build', {}, hooks)
+			.then(stream => {
+				if (displayOutput) {
+					stream.pipe(process.stdout);
+				}
+			});
+	});
+
 	it('should fail to build a directory without Dockerfile', function(done) {
 		this.timeout(30000);
 

--- a/test/utils_test.ts
+++ b/test/utils_test.ts
@@ -1,0 +1,28 @@
+import { expect } from 'chai';
+import { extractFromTag } from '../src/utils';
+
+describe('utils', () => {
+	it('can extract FROM statements', () => {
+		expect(extractFromTag('FROM ubuntu:18.04')).to.deep.equal({
+			repo: 'ubuntu',
+			tag: '18.04',
+		});
+		expect(extractFromTag('Step 1/28 : FROM ubuntu')).to.deep.equal({
+			repo: 'ubuntu',
+			tag: 'latest',
+		});
+		expect(extractFromTag('something different')).to.be.equal(undefined);
+		expect(extractFromTag('Step 1/28 : FROM ubuntu as base')).to.deep.equal({
+			repo: 'ubuntu',
+			tag: 'latest',
+			alias: 'base',
+		});
+		expect(
+			extractFromTag('Step 1/28 : FROM some/image-name:1.2.3-tag as my-name'),
+		).to.deep.equal({
+			repo: 'some/image-name',
+			tag: '1.2.3-tag',
+			alias: 'my-name',
+		});
+	});
+});


### PR DESCRIPTION
The interface is extended to provide information about image tags
used in FROM instructions during the build.
It should not add too much overhead to what is already done by the library,
but will expose quite interesting details useful in build analysis.

Change-type: minor
Signed-off-by: Roman Mazur <roman@balena.io>